### PR TITLE
Added GuitarState abstract class and 6 state classes

### DIFF
--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/DualNeckGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/DualNeckGuitarState.kt
@@ -1,0 +1,12 @@
+package android.clicker.school_live_simulator
+
+class DualNeckGuitarState: FenderGuitarState() {
+    override val price: Int = 150000
+
+    init {
+
+    }
+
+    override fun changeState(bag: Player.Bag):
+        Unit = throw UnsupportedOperationException("Operation not supported")
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/DualNeckGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/DualNeckGuitarState.kt
@@ -4,7 +4,7 @@ class DualNeckGuitarState: FenderGuitarState() {
     override val price: Int = 150000
 
     init {
-
+        available_courses.add(MusicalObservatoryCourseState::class)
     }
 
     override fun changeState(bag: Player.Bag):

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/FenderGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/FenderGuitarState.kt
@@ -4,10 +4,10 @@ open class FenderGuitarState : YamahaGuitarState() {
     override val price: Int = 40000
 
     init {
-        available_courses.add(MusicalObservatoryCourseState::class)
+        available_courses.add(MusicalSchoolCourseState::class)
     }
 
     override fun changeState(bag: Player.Bag) {
-        bag.guitar = DualNeckGuitarState()
+        bag.setGuitar(DualNeckGuitarState())
     }
 }

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/FenderGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/FenderGuitarState.kt
@@ -8,6 +8,6 @@ open class FenderGuitarState : YamahaGuitarState() {
     }
 
     override fun changeState(bag: Player.Bag) {
-        bag.setGuitar(DualNeckGuitarState())
+        bag.guitar = DualNeckGuitarState()
     }
 }

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/FenderGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/FenderGuitarState.kt
@@ -4,7 +4,7 @@ open class FenderGuitarState : YamahaGuitarState() {
     override val price: Int = 40000
 
     init {
-        available_courses.add("MusicalObservatoryCourseState")
+        available_courses.add(MusicalObservatoryCourseState::class)
     }
 
     override fun changeState(bag: Player.Bag) {

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/FenderGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/FenderGuitarState.kt
@@ -1,0 +1,13 @@
+package android.clicker.school_live_simulator
+
+open class FenderGuitarState : YamahaGuitarState() {
+    override val price: Int = 40000
+
+    init {
+        available_courses.add("MusicalObservatoryCourseState")
+    }
+
+    override fun changeState(bag: Player.Bag) {
+        bag.guitar = DualNeckGuitarState()
+    }
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/GuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/GuitarState.kt
@@ -1,8 +1,10 @@
 package android.clicker.school_live_simulator
 
+import kotlin.reflect.KClass
+
 abstract class GuitarState {
     protected abstract val price: Int
-    protected val available_courses: ArrayList<String> = arrayListOf()
+    protected val available_courses: ArrayList<KClass<*>> = arrayListOf()
 
     /**
      * Updates the state of the purchased guitar.
@@ -17,7 +19,7 @@ abstract class GuitarState {
      * @param    courseName  name of the course
      * @return               course availability (true/false)
      */
-    open fun isAvailable(courseName: String): Boolean {
+    open fun isAvailable(courseName: KClass<*>): Boolean {
         return available_courses.contains(courseName)
     }
 }

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/GuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/GuitarState.kt
@@ -3,7 +3,7 @@ package android.clicker.school_live_simulator
 import kotlin.reflect.KClass
 
 abstract class GuitarState {
-    protected abstract val price: Int
+    abstract val price: Int
     protected val available_courses: ArrayList<KClass<*>> = arrayListOf()
 
     /**

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/GuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/GuitarState.kt
@@ -1,0 +1,26 @@
+package android.clicker.school_live_simulator
+
+/**
+ * @author  Nikita Dimitryuk niksvob@mail.ru
+ */
+abstract class GuitarState {
+    protected abstract val price: Int
+    protected val available_courses: ArrayList<String> = arrayListOf()
+
+    /**
+     * Updates the state of the purchased guitar.
+     *
+     * @param    bag player inventory
+     */
+    abstract fun changeState(bag: Player.Bag)
+
+    /**
+     * Function checks if the course is available
+     *
+     * @param    courseName  name of the course
+     * @return               course availability (true/false)
+     */
+    open fun isAvailable(courseName: String): Boolean {
+        return available_courses.contains(courseName)
+    }
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/GuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/GuitarState.kt
@@ -1,8 +1,5 @@
 package android.clicker.school_live_simulator
 
-/**
- * @author  Nikita Dimitryuk niksvob@mail.ru
- */
 abstract class GuitarState {
     protected abstract val price: Int
     protected val available_courses: ArrayList<String> = arrayListOf()

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/NullGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/NullGuitarState.kt
@@ -1,0 +1,9 @@
+package android.clicker.school_live_simulator
+
+open class NullGuitarState : GuitarState() {
+    override val price: Int = 0
+
+    override fun changeState(bag: Player.Bag) {
+        bag.guitar = UssrGuitarState()
+    }
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/NullGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/NullGuitarState.kt
@@ -4,6 +4,6 @@ open class NullGuitarState : GuitarState() {
     override val price: Int = 0
 
     override fun changeState(bag: Player.Bag) {
-        bag.setGuitar(UssrGuitarState())
+        bag.guitar = UssrGuitarState()
     }
 }

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/NullGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/NullGuitarState.kt
@@ -4,6 +4,6 @@ open class NullGuitarState : GuitarState() {
     override val price: Int = 0
 
     override fun changeState(bag: Player.Bag) {
-        bag.guitar = UssrGuitarState()
+        bag.setGuitar(UssrGuitarState())
     }
 }

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/UralGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/UralGuitarState.kt
@@ -4,7 +4,7 @@ open class UralGuitarState : UssrGuitarState() {
     override val price: Int = 5000
 
     init {
-        available_courses.add("YardSongCourseState")
+        available_courses.add(YardSongCourseState::class)
     }
 
     override fun changeState(bag: Player.Bag) {

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/UralGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/UralGuitarState.kt
@@ -8,6 +8,6 @@ open class UralGuitarState : UssrGuitarState() {
     }
 
     override fun changeState(bag: Player.Bag) {
-        bag.setGuitar(YamahaGuitarState())
+        bag.guitar = YamahaGuitarState()
     }
 }

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/UralGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/UralGuitarState.kt
@@ -4,10 +4,10 @@ open class UralGuitarState : UssrGuitarState() {
     override val price: Int = 5000
 
     init {
-        available_courses.add(YardSongCourseState::class)
+        available_courses.add(FirstSongCourseState::class)
     }
 
     override fun changeState(bag: Player.Bag) {
-        bag.guitar = YamahaGuitarState()
+        bag.setGuitar(YamahaGuitarState())
     }
 }

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/UralGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/UralGuitarState.kt
@@ -1,0 +1,13 @@
+package android.clicker.school_live_simulator
+
+open class UralGuitarState : UssrGuitarState() {
+    override val price: Int = 5000
+
+    init {
+        available_courses.add("YardSongCourseState")
+    }
+
+    override fun changeState(bag: Player.Bag) {
+        bag.guitar = YamahaGuitarState()
+    }
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/UssrGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/UssrGuitarState.kt
@@ -8,6 +8,6 @@ open class UssrGuitarState : NullGuitarState() {
     }
 
     override fun changeState(bag: Player.Bag) {
-        bag.setGuitar(UralGuitarState())
+        bag.guitar = UralGuitarState()
     }
 }

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/UssrGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/UssrGuitarState.kt
@@ -4,7 +4,7 @@ open class UssrGuitarState : NullGuitarState() {
     override val price: Int = 1000
 
     init {
-        available_courses.add("FirstSongCourseState")
+        available_courses.add(FirstSongCourseState::class)
     }
 
     override fun changeState(bag: Player.Bag) {

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/UssrGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/UssrGuitarState.kt
@@ -4,10 +4,10 @@ open class UssrGuitarState : NullGuitarState() {
     override val price: Int = 1000
 
     init {
-        available_courses.add(FirstSongCourseState::class)
+        available_courses.add(YardGuitarCourseState::class)
     }
 
     override fun changeState(bag: Player.Bag) {
-        bag.guitar = UralGuitarState()
+        bag.setGuitar(UralGuitarState())
     }
 }

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/UssrGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/UssrGuitarState.kt
@@ -1,0 +1,13 @@
+package android.clicker.school_live_simulator
+
+open class UssrGuitarState : NullGuitarState() {
+    override val price: Int = 1000
+
+    init {
+        available_courses.add("FirstSongCourseState")
+    }
+
+    override fun changeState(bag: Player.Bag) {
+        bag.guitar = UralGuitarState()
+    }
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/YamahaGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/YamahaGuitarState.kt
@@ -4,10 +4,10 @@ open class YamahaGuitarState : UralGuitarState() {
     override val price: Int = 12000
 
     init {
-        available_courses.add(MusicalSchoolCourseState::class)
+        available_courses.add(YardSongCourseState::class)
     }
 
     override fun changeState(bag: Player.Bag) {
-        bag.guitar = FenderGuitarState()
+        bag.setGuitar(FenderGuitarState())
     }
 }

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/YamahaGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/YamahaGuitarState.kt
@@ -4,7 +4,7 @@ open class YamahaGuitarState : UralGuitarState() {
     override val price: Int = 12000
 
     init {
-        available_courses.add("MusicalSchoolCourseState")
+        available_courses.add(MusicalSchoolCourseState::class)
     }
 
     override fun changeState(bag: Player.Bag) {

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/YamahaGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/YamahaGuitarState.kt
@@ -1,0 +1,13 @@
+package android.clicker.school_live_simulator
+
+open class YamahaGuitarState : UralGuitarState() {
+    override val price: Int = 12000
+
+    init {
+        available_courses.add("MusicalSchoolCourseState")
+    }
+
+    override fun changeState(bag: Player.Bag) {
+        bag.guitar = FenderGuitarState()
+    }
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/YamahaGuitarState.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/YamahaGuitarState.kt
@@ -8,6 +8,6 @@ open class YamahaGuitarState : UralGuitarState() {
     }
 
     override fun changeState(bag: Player.Bag) {
-        bag.setGuitar(FenderGuitarState())
+        bag.guitar = FenderGuitarState()
     }
 }


### PR DESCRIPTION
Added GuitarState abstract class and 6 state classes
-    Abstract class GuitarState (defines state of the purchased guitars)
-    Subclass NullGuitarState (defines no guitar state)
-    Subclass UssrGuitarState (defines an old guitar from the USSR state)
-    Subclass UralGuitarState (defines the Ural guitar state)
-    Subclass YamahaGuitarState (defines the Yamaha guitar state)
-    Subclass FenderGuitarState (defines the Fender guitar state)
-    Subclass DualNeckGuitarState (defines a dual neck guitar state)