### PR TITLE
Implement Achievements Enum classes and Randomization method

### DIFF
--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Interfaces/Achievements.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Interfaces/Achievements.kt
@@ -1,0 +1,10 @@
+package android.clicker.school_live_simulator.Classes.Achievements_classes.Interfaces
+
+/**
+ * Marker interface
+ *
+ * All types of achievements
+ */
+interface Achievements {
+
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Interfaces/PurchaseAchievements.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Interfaces/PurchaseAchievements.kt
@@ -1,0 +1,11 @@
+package android.clicker.school_live_simulator.Classes.Achievements_classes.Interfaces
+
+/**
+ * Marker interface
+ *
+ * Purchase Achievements - the type of achievement a player gets with
+ *                         some chance when eating a certain food
+ */
+interface PurchaseAchievements: Achievements {
+
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Interfaces/RandomAchievements.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Interfaces/RandomAchievements.kt
@@ -1,0 +1,11 @@
+package android.clicker.school_live_simulator.Classes.Achievements_classes.Interfaces
+
+/**
+ * Marker interface
+ *
+ * Random Achievements - the type of achievements that a player gets with
+ *                       some chance when performing certain actions
+ */
+interface RandomAchievements: Achievements {
+
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Interfaces/SpecialAchievements.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Interfaces/SpecialAchievements.kt
@@ -1,0 +1,11 @@
+package android.clicker.school_live_simulator.Classes.Achievements_classes.Interfaces
+
+/**
+ * Marker interface
+ *
+ * Special Achievements - the type of achievements that a player gets with
+ *                        some chance when performing special actions
+ */
+interface SpecialAchievements: Achievements {
+
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Purchase_achievements/BicycleEventsAchievements.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Purchase_achievements/BicycleEventsAchievements.kt
@@ -1,0 +1,12 @@
+package android.clicker.school_live_simulator.Classes.Achievements_classes.Purchase_achievements
+
+import android.clicker.school_live_simulator.Classes.Achievements_classes.Interfaces.PurchaseAchievements
+import android.clicker.school_live_simulator.Game
+
+/**
+ * Purchase Achievements related to the purchase of a bicycle
+ */
+enum class BicycleEventsAchievements(val achievement_name: String, val achievement_message: String): PurchaseAchievements {
+    USUAL_BIKE(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    MOUNTAIN_BIKE(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle(""))
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Purchase_achievements/ComputerEventsAchievements.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Purchase_achievements/ComputerEventsAchievements.kt
@@ -1,0 +1,13 @@
+package android.clicker.school_live_simulator.Classes.Achievements_classes.Purchase_achievements
+
+import android.clicker.school_live_simulator.Classes.Achievements_classes.Interfaces.PurchaseAchievements
+import android.clicker.school_live_simulator.Game
+
+/**
+ * Purchase Achievements related to the purchase of a computer
+ */
+enum class ComputerEventsAchievements(val achievement_name: String, val achievement_message: String): PurchaseAchievements {
+    PREVIOUSLY_USED_COMPUTER(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    XIAOMI_MI_NOTEBOOK(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    MACBOOK(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle(""))
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Purchase_achievements/GuitarEventsAchievements.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Purchase_achievements/GuitarEventsAchievements.kt
@@ -1,0 +1,15 @@
+package android.clicker.school_live_simulator.Classes.Achievements_classes.Purchase_achievements
+
+import android.clicker.school_live_simulator.Classes.Achievements_classes.Interfaces.PurchaseAchievements
+import android.clicker.school_live_simulator.Game
+
+/**
+ * Purchase Achievements related to the purchase of a guitar
+ */
+enum class GuitarEventsAchievements(val achievement_name: String, val achievement_message: String): PurchaseAchievements {
+    USSR_GUITAR(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    URAL_GUITAR(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    YAMAHA_GUITAR(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    FENDER_GUITAR(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    DUAL_NECK_GUITAR(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle(""))
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Random_achievements/CreativityEventsRandomAchievements.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Random_achievements/CreativityEventsRandomAchievements.kt
@@ -1,0 +1,15 @@
+package android.clicker.school_live_simulator.Classes.Achievements_classes.Random_achievements
+
+import android.clicker.school_live_simulator.Classes.Achievements_classes.Interfaces.RandomAchievements
+import android.clicker.school_live_simulator.Game
+
+/**
+ * Random achievements related to creativity
+ */
+enum class CreativityEventsRandomAchievements(val achievement_name: String, val achievement_message: String): RandomAchievements {
+    DRAW_ON_TOP_OF_OTHER_ART(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    MISTER_PROPER(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    IVANS_INTERNATIONAL(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    POEM_IN_SPOTLIGHT(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    SONG_IN_SPOTLIGHT(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle(""))
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Random_achievements/EntertainmentEventsRandomAchievements.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Random_achievements/EntertainmentEventsRandomAchievements.kt
@@ -1,0 +1,24 @@
+package android.clicker.school_live_simulator.Classes.Achievements_classes.Random_achievements
+
+import android.clicker.school_live_simulator.Classes.Achievements_classes.Interfaces.RandomAchievements
+import android.clicker.school_live_simulator.Game
+
+/**
+ * Random achievements related to entertainment
+ */
+enum class EntertainmentEventsRandomAchievements(val achievement_name: String, val achievement_message: String): RandomAchievements {
+    CAM2CAM_TRAP(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    GET_BAN(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    BE_REPORTED_BY_CHILDREN(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    BOTTLE_FLIP(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    FUTURE_PIMP(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    FUTURE_GAY_PIMP(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    FRIEND_IN_THEATRE(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    MOMS_HACKERMAN(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    EVACUATE_FROM_SHOP_CENTRE(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    SEX_SCENE_IN_BOOK(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    GET_TIP_FROM_YOUNGS(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    DESTROYED_HOUSE(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    PHOTO_WITH_VOCALIST(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    TOO_FAST_RUNNING(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle(""))
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Random_achievements/FoodEventsRandomAchievements.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Random_achievements/FoodEventsRandomAchievements.kt
@@ -1,0 +1,12 @@
+package android.clicker.school_live_simulator.Classes.Achievements_classes.Random_achievements
+
+import android.clicker.school_live_simulator.Classes.Achievements_classes.Interfaces.RandomAchievements
+import android.clicker.school_live_simulator.Game
+
+/**
+ * Random food-related achievements
+ */
+enum class FoodEventsRandomAchievements(val achievement_name: String, val achievement_message: String): RandomAchievements {
+    TWO_SPICES(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    POISONING_OF_EATERY_FOOD(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle(""))
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Random_achievements/SongEventsRandomAchievements.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Random_achievements/SongEventsRandomAchievements.kt
@@ -1,0 +1,12 @@
+package android.clicker.school_live_simulator.Classes.Achievements_classes.Random_achievements
+
+import android.clicker.school_live_simulator.Classes.Achievements_classes.Interfaces.RandomAchievements
+import android.clicker.school_live_simulator.Game
+
+/**
+ * Random song-related achievements
+ */
+enum class SongEventsRandomAchievements(val achievement_name: String, val achievement_message: String): RandomAchievements {
+    WRONG_CHORDS(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    IN_SPOTLIGHT(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle(""))
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Random_achievements/StudyEventsRandomAchievements.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Random_achievements/StudyEventsRandomAchievements.kt
@@ -1,0 +1,15 @@
+package android.clicker.school_live_simulator.Classes.Achievements_classes.Random_achievements
+
+import android.clicker.school_live_simulator.Classes.Achievements_classes.Interfaces.RandomAchievements
+import android.clicker.school_live_simulator.Game
+
+/**
+ * Random achievements related to education
+ */
+enum class StudyEventsRandomAchievements(val achievement_name: String, val achievement_message: String): RandomAchievements {
+    DRUNK_STUDENT(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    PAR_ABOUT_REPRODUCTIVE(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    OLD_ANSWER_BOOK(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    FALL_ASLEEP_AT_WEBINAR(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    STORIES_ABOUT_USSR(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle(""))
+}

--- a/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Special_achievements/SpecialEventsAchievements.kt
+++ b/Project_source/app/src/main/java/android/clicker/school_live_simulator/Classes/Achievements_classes/Special_achievements/SpecialEventsAchievements.kt
@@ -1,0 +1,16 @@
+package android.clicker.school_live_simulator.Classes.Achievements_classes.Special_achievements
+
+import android.clicker.school_live_simulator.Classes.Achievements_classes.Interfaces.SpecialAchievements
+import android.clicker.school_live_simulator.Game
+
+/**
+ * Special Achievements related to player's special actions
+ */
+enum class SpecialEventsAchievements(val achievement_name: String, val achievement_message: String): SpecialAchievements {
+    SPARTAK_WINNER(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    ZENIT_WINNER(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    JOIN_TO_WINNERS(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    JOIN_TO_LOSERS(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    MOMS_BUSINESSMAN(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle("")),
+    MOMS_NOT_BUSSINESSMAN(achievement_name = Game.context_bundle.getTitle(""), achievement_message = Game.context_bundle.getTitle(""))
+}


### PR DESCRIPTION
Interfaces: Add
- Achievements, PurchaseAchievements, RandomAchievements, SpecialAchievements - marker interfaces that define different types of achievements

Enum classes: Add
- Nine types of achievements:
	- BicycleEventsAchievements - Purchase Achievements related to the purchase of a bicycle
	- ComputerEventsAchievements - Purchase Achievements related to the purchase of a computer
	- GuitarEventsAchievements - Purchase Achievements related to the purchase of a guitar

	- CreativityEventsRandomAchievements - Random achievements related to creativity
	- EntertainmentEventsRandomAchievements - Random achievements related to entertainment
	- FoodEventsRandomAchievements - Random food-related achievements
	- SongEventsRandomAchievements - Random song-related achievements
	- StudyEventsRandomAchievements - Random achievements related to education

	- SpecialEventsAchievements - Special Achievements related to player's special actions